### PR TITLE
startup-hiring-best-practices

### DIFF
--- a/startup-hiring-best-practices
+++ b/startup-hiring-best-practices
@@ -1,0 +1,7 @@
+When starting up a new technology company, some founders focus on hiring a CTO first, but the most practical first hire is actually a devloper.
+Once you've hired ~5 developers, hiring a product manager to help guide strategy and product development is the next step.
+With 10-15 developers, it's time to hire a VP of Engineering to oversee this sizeable technical division of the organization.
+Once you have 25-30 developers, it is then time to start thinking about bringing on a CTO.
+By taking this approach, you avoid hiring the CTO too early. Since the CTO is the most expensive of these hires but may have the least technical ability a this stage in his career, it makes sense to hold off until this point.
+As The Lean Startup recommends, the key question a founder/CEO should be answering in the early stages is not how to build software efficiently (the CTO's job), but rather, what exactly to build and whether it makes sense to build it at all.
+For more on this topic, check out: http://www.amazon.com/The-Lean-Startup-Entrepreneurs-Continuous/dp/0307887898


### PR DESCRIPTION
When starting up a new technology company, some founders focus on hiring a CTO first, but the most practical first hire is actually a devloper.
Once you've hired ~5 developers, hiring a product manager to help guide strategy and product development is the next step.
With 10-15 developers, it's time to hire a VP of Engineering to oversee this sizeable technical division of the organization.
Once you have 25-30 developers, it is then time to start thinking about bringing on a CTO.
By taking this approach, you avoid hiring the CTO too early. Since the CTO is the most expensive of these hires but may have the least technical ability a this stage in his career, it makes sense to hold off until this point.
As The Lean Startup recommends, the key question a founder/CEO should be answering in the early stages is not how to build software efficiently (the CTO's job), but rather, what exactly to build and whether it makes sense to build it at all.
For more on this topic, check out: http://www.amazon.com/The-Lean-Startup-Entrepreneurs-Continuous/dp/0307887898
